### PR TITLE
Fix code scanning alert no. 773: Potential use after free

### DIFF
--- a/deps/openssl/openssl/ssl/statem/extensions_clnt.c
+++ b/deps/openssl/openssl/ssl/statem/extensions_clnt.c
@@ -1650,21 +1650,18 @@ int tls_parse_stoc_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 
     OPENSSL_free(s->s3.alpn_selected);
     s->s3.alpn_selected = NULL;
-    s->s3.alpn_selected = OPENSSL_malloc(len);
-    if (s->s3.alpn_selected == NULL) {
-        s->s3.alpn_selected_len = 0;
-        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-        return 0;
-    }
-    if (!PACKET_copy_bytes(pkt, s->s3.alpn_selected, len)) {
-        SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_BAD_EXTENSION);
-        return 0;
-    }
-    s->s3.alpn_selected_len = len;
-
-    if (s->s3.alpn_selected == NULL) {
-        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-        return 0;
+    if (len > 0) {
+        s->s3.alpn_selected = OPENSSL_malloc(len);
+        if (s->s3.alpn_selected == NULL) {
+            s->s3.alpn_selected_len = 0;
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+            return 0;
+        }
+        if (!PACKET_copy_bytes(pkt, s->s3.alpn_selected, len)) {
+            SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_BAD_EXTENSION);
+            return 0;
+        }
+        s->s3.alpn_selected_len = len;
     }
 
     if (s->session->ext.alpn_selected == NULL


### PR DESCRIPTION
Fixes [https://github.com/akadev1/potential-octo-tribble/security/code-scanning/773](https://github.com/akadev1/potential-octo-tribble/security/code-scanning/773)

To fix the problem, we need to ensure that `s->s3.alpn_selected` is not accessed after it has been freed and before it is reallocated. This can be achieved by adding a `NULL` check before the reallocation and ensuring that the pointer is not used if the reallocation fails. Additionally, we should remove redundant `NULL` checks after the pointer has been reallocated successfully.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
